### PR TITLE
Changed how the color is automatically generated

### DIFF
--- a/src/main/java/thelm/jaopca/ore/OreColorer.java
+++ b/src/main/java/thelm/jaopca/ore/OreColorer.java
@@ -1,16 +1,7 @@
 package thelm.jaopca.ore;
 
-import java.awt.Color;
-import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import de.androidpit.colorthief.ColorThief;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -21,115 +12,139 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.oredict.OreDictionary;
 import thelm.jaopca.api.utils.Utils;
 
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Code partially taken from mezz's JEI
  */
 public class OreColorer {
 
-	public static final HashMap<String, Color> DEFAULT_COLORS = Maps.<String, Color>newHashMap();
+    public static final HashMap<String, Color> DEFAULT_COLORS = Maps.<String, Color>newHashMap();
 
-	static {
+    static {
 
-	}
+    }
 
-	public static Color getColor(String prefix, String oreName) {
-		if(DEFAULT_COLORS.containsKey(oreName)) {
-			return DEFAULT_COLORS.get(oreName);
-		}
+    public static Color getAverageColorFromTexture(BufferedImage image) {
 
-		List<ItemStack> ores = Utils.getOres(prefix+oreName);
-		if(ores.isEmpty()) {
-			return Color.WHITE;
-		}
+        long r = 0, g = 0, b = 0;
+        long amt = 0;
 
-		List<int[]> colors = Lists.<int[]>newArrayList();
-		for(ItemStack stack : ores) {
-			List<BakedQuad> quads = getBakedQuads(stack).stream().sorted((quad0, quad1)->Integer.compare(quad1.getTintIndex(), quad0.getTintIndex())).collect(Collectors.toList());
-			if(quads.isEmpty()) {
-				continue;
-			}
-			int colorMultiplier = getColorMultiplier(stack, quads.get(0));
-			for(BakedQuad quad : quads) {
-				BufferedImage texture = getBufferedImage(quad.getSprite());
-				if(texture == null) {
-					continue;
-				}
-				int[][] texColors = ColorThief.getPalette(texture, 4);
-				if(texColors == null) {
-					continue;
-				}
-				int[] texColor = texColors[0];
-				if(texColor == null) {
-					continue;
-				}
-				texColor[0] = (int)MathHelper.clamp(texColor[0]*(colorMultiplier>>16&0xFF)/255D, 0, 255);
-				texColor[1] = (int)MathHelper.clamp(texColor[1]*(colorMultiplier>> 8&0xFF)/255D, 0, 255);
-				texColor[2] = (int)MathHelper.clamp(texColor[2]*(colorMultiplier    &0xFF)/255D, 0, 255);
-				colors.add(texColor);
-			}
-		}
+        for (int i = 0; i < image.getWidth(); i++) {
+            for (int j = 0; j < image.getHeight(); j++) {
+                Color color = new Color(image.getRGB(i, j), true);
+                if (color.getAlpha() < 50)
+                    continue;
 
-		double count = colors.size();
-		if(count == 0) {
-			return Color.WHITE;
-		}
-		long red = 0;
-		long green = 0;
-		long blue = 0;
-		for(int[] c : colors) {
-			red += c[0]*c[0];
-			green += c[1]*c[1];
-			blue += c[2]*c[2];
-		}
-		return new Color((int)Math.sqrt(red/count), (int)Math.sqrt(green/count), (int)Math.sqrt(blue/count));
-	}
+                r += color.getRed();
+                g += color.getGreen();
+                b += color.getBlue();
+                amt++;
+            }
+        }
+        if (amt == 0) return Color.WHITE;
+        return new Color((int) MathHelper.clamp(r / amt, 0, 255),
+                (int) MathHelper.clamp(g / amt, 0, 255), (int) MathHelper.clamp(b / amt, 0, 255)).brighter();
+    }
 
-	private static BufferedImage getBufferedImage(TextureAtlasSprite textureAtlasSprite) {
-		if(textureAtlasSprite == null) {
-			return null;
-		}
-		final int iconWidth = textureAtlasSprite.getIconWidth();
-		final int iconHeight = textureAtlasSprite.getIconHeight();
-		final int frameCount = textureAtlasSprite.getFrameCount();
-		if(iconWidth <= 0 || iconHeight <= 0 || frameCount <= 0) {
-			return null;
-		}
+    public static Color getColor(String prefix, String oreName) {
+        if (DEFAULT_COLORS.containsKey(oreName)) {
+            return DEFAULT_COLORS.get(oreName);
+        }
 
-		BufferedImage bufferedImage = new BufferedImage(iconWidth, iconHeight * frameCount, BufferedImage.TYPE_4BYTE_ABGR);
-		for(int i = 0; i < frameCount; i++) {
-			int[][] frameTextureData = textureAtlasSprite.getFrameTextureData(i);
-			int[] largestMipMapTextureData = frameTextureData[0];
-			bufferedImage.setRGB(0, i * iconHeight, iconWidth, iconHeight, largestMipMapTextureData, 0, iconWidth);
-		}
+        List<ItemStack> ores = Utils.getOres(prefix + oreName);
+        if (ores.isEmpty()) {
+            return Color.WHITE;
+        }
 
-		return bufferedImage;
-	}
+        List<int[]> colors = Lists.<int[]>newArrayList();
+        for (ItemStack stack : ores) {
+            List<BakedQuad> quads = getBakedQuads(stack).stream().sorted((quad0, quad1) -> Integer.compare(quad1.getTintIndex(), quad0.getTintIndex())).collect(Collectors.toList());
+            if (quads.isEmpty()) {
+                continue;
+            }
+            int colorMultiplier = getColorMultiplier(stack, quads.get(0));
+            for (BakedQuad quad : quads) {
+                BufferedImage texture = getBufferedImage(quad.getSprite());
+                if (texture == null) {
+                    continue;
+                }
 
-	private static List<BakedQuad> getBakedQuads(ItemStack itemStack) {
-		IBakedModel model = Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(itemStack, null, null);
-		ArrayList<BakedQuad> list = Lists.<BakedQuad>newArrayList();
-		for(EnumFacing facing : EnumFacing.values()) {
-			list.addAll(model.getQuads(null, facing, 0).stream().filter(quad->quad.getFace() == EnumFacing.SOUTH).collect(Collectors.toList()));
-		}
-		list.addAll(model.getQuads(null, null, 0).stream().filter(quad->quad.getFace() == EnumFacing.SOUTH).collect(Collectors.toList()));
-		return list;
-	}
+                Color color = getAverageColorFromTexture(texture);
+                Color colorMult = new Color(colorMultiplier);
+                colors.add(new int[]{(int) MathHelper.clamp(color.getRed() * colorMult.getRed() / 255D, 0, 255),
+                        (int) MathHelper.clamp(color.getGreen() * colorMult.getGreen() / 255D, 0, 255),
+                        (int) MathHelper.clamp(color.getBlue() * colorMult.getBlue() / 255D, 0, 255)});
+            }
+        }
 
-	private static int getColorMultiplier(ItemStack itemStack, BakedQuad quad) {
-		return Minecraft.getMinecraft().getItemColors().getColorFromItemstack(itemStack, quad.getTintIndex());
-	}
+        double count = colors.size();
+        if (count == 0) {
+            return Color.WHITE;
+        }
+        long red = 0;
+        long green = 0;
+        long blue = 0;
+        for (int[] c : colors) {
+            red += c[0] * c[0];
+            green += c[1] * c[1];
+            blue += c[2] * c[2];
+        }
 
-	public static boolean getHasEffect(String prefix, String oreName) {
-		List<ItemStack> ores = OreDictionary.getOres(prefix+oreName, false);
-		if(ores.isEmpty()) {
-			return false;
-		}
+        return new Color((int) Math.sqrt(red / count), (int) Math.sqrt(green / count), (int) Math.sqrt(blue / count));
+    }
 
-		for(ItemStack ore : ores) {
-			if(ore.hasEffect()) {
-				return true;
-			}
-		}
-		return false;
-	}
+    private static BufferedImage getBufferedImage(TextureAtlasSprite textureAtlasSprite) {
+        if (textureAtlasSprite == null) {
+            return null;
+        }
+        final int iconWidth = textureAtlasSprite.getIconWidth();
+        final int iconHeight = textureAtlasSprite.getIconHeight();
+        final int frameCount = textureAtlasSprite.getFrameCount();
+        if (iconWidth <= 0 || iconHeight <= 0 || frameCount <= 0) {
+            return null;
+        }
+
+        BufferedImage bufferedImage = new BufferedImage(iconWidth, iconHeight * frameCount, BufferedImage.TYPE_4BYTE_ABGR);
+        for (int i = 0; i < frameCount; i++) {
+            int[][] frameTextureData = textureAtlasSprite.getFrameTextureData(i);
+            int[] largestMipMapTextureData = frameTextureData[0];
+            bufferedImage.setRGB(0, i * iconHeight, iconWidth, iconHeight, largestMipMapTextureData, 0, iconWidth);
+        }
+
+        return bufferedImage;
+    }
+
+    private static List<BakedQuad> getBakedQuads(ItemStack itemStack) {
+        IBakedModel model = Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(itemStack, null, null);
+        ArrayList<BakedQuad> list = Lists.<BakedQuad>newArrayList();
+        for (EnumFacing facing : EnumFacing.values()) {
+            list.addAll(model.getQuads(null, facing, 0).stream().filter(quad -> quad.getFace() == EnumFacing.SOUTH).collect(Collectors.toList()));
+        }
+        list.addAll(model.getQuads(null, null, 0).stream().filter(quad -> quad.getFace() == EnumFacing.SOUTH).collect(Collectors.toList()));
+        return list;
+    }
+
+    private static int getColorMultiplier(ItemStack itemStack, BakedQuad quad) {
+        return Minecraft.getMinecraft().getItemColors().getColorFromItemstack(itemStack, quad.getTintIndex());
+    }
+
+    public static boolean getHasEffect(String prefix, String oreName) {
+        List<ItemStack> ores = OreDictionary.getOres(prefix + oreName, false);
+        if (ores.isEmpty()) {
+            return false;
+        }
+
+        for (ItemStack ore : ores) {
+            if (ore.hasEffect()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
So, the colors generated automatically seemed too dark.

Materials like gold and yellorium looked especially bad while others just all seemed like the same dark colors or gray/black. (The gold and yellorium aren't shown in the pic below)

Here's a before and after pic
![beforeafter](https://user-images.githubusercontent.com/18143350/42917060-f1e29abe-8ad5-11e8-854f-82f8e1dabed4.PNG)


The reason it's average and brighter, and why I think it works,
is that the ColorThief.getPalette seems to find the black border and counts that as being a large part of the image, since it seems to find the colors of the same value (light yellow is not the same as normal or darker yellows) So black was a large factor, making it much darker.  

The average without the brightness did help as the black border is taken less into account (darker colors have lower rgb values than bright color), but it still seemed to dark. The brighter modifier seemed to make it reasonable.  A lot more of the gems and metals that appear to have a shine effect actually get some of that now, instead of all being dull.

Yellorium actually looks like yellow now due to both average and brighter. It's not perfect, but it's better.
![yellorium](https://user-images.githubusercontent.com/18143350/42917106-2d02edb0-8ad6-11e8-9106-60f4173d2570.PNG)

I did try ColorThief.getColor and that was too bright and made things seem too saturated.

So, this removes the need for ColorThief, but I didn't remove it just in case.

And I'm interested in doing this as I'm working on my tech mod which uses JAOPCA to generate the missing materials, and I couldn't stand some of the colors.  They just didn't match.