### PR TITLE
Add support for having ore slurry be "colored"

### DIFF
--- a/src/main/java/thelm/jaopca/modules/ModuleMekanism.java
+++ b/src/main/java/thelm/jaopca/modules/ModuleMekanism.java
@@ -361,6 +361,11 @@ public class ModuleMekanism extends ModuleBase {
 		}
 
 		@Override
+		public int getTint() {
+			return oreEntry.getColor();
+		}
+
+		@Override
 		public String getLocalizedName() {
 			return Utils.smartLocalize(this.getUnlocalizedName(), this.getUnlocalizedName()+".%s", this.getOreEntry());
 		}


### PR DESCRIPTION
I did some testing and managed to get it working with this change. (Apparently the oreEntry color is not initialized yet where I was suggesting to set the color, so I am just having the gas implementation return it. This makes it so when it is queried later it will return the correct value then.

The attached image shows how Ardite Slurry to Clean Ardite Slurry now appears, the before picture is the same as the first picture in #109 

![ardite slurry](https://user-images.githubusercontent.com/1203288/53306632-82422e00-385d-11e9-8dcd-85fca9c9ca74.jpg)

The slurries added by JAOPCA now also render properly in machines and pressurized tubes, instead of just being the default color.