### PR TITLE
Fixed alltheores prefix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ sourceSets {
     main
 }
 
-version = "3.4.0.6"
+version = "3.4.0.7"
 group = "thelm.jaopca"
 archivesBaseName = "JAOPCA-1.16.5"
 

--- a/src/main/java/thelm/jaopca/compat/mekanism/MekanismModule.java
+++ b/src/main/java/thelm/jaopca/compat/mekanism/MekanismModule.java
@@ -44,7 +44,7 @@ public class MekanismModule implements IModule {
 		if(ModList.get().isLoaded("allthemodium")) {
 			Collections.addAll(BLACKLIST, "allthemodium", "unabtainium", "vibranium");
 		}
-		if(ModList.get().isLoaded("ato")) {
+		if(ModList.get().isLoaded("alltheores")) {
 			Collections.addAll(BLACKLIST, "aluminum", "aluminium", "nickel", "platinum", "silver", "zinc");
 		}
 	}


### PR DESCRIPTION
Fixed blacklist not being applied when alltheores is loaded with mekanism, resulting in double recepies for some slurries.

Issue:
https://github.com/AllTheMods/atm6-sky/issues/96

**Additional context**
_ato_ is the correct name for the maven repo in cursemaven, but it's not the mod's name.