### PR TITLE
Fix TagManager is not first (Pollen add itself as first)

### DIFF
--- a/src/main/java/thelm/jaopca/events/CommonEventHandler.java
+++ b/src/main/java/thelm/jaopca/events/CommonEventHandler.java
@@ -1,6 +1,7 @@
 package thelm.jaopca.events;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -9,6 +10,7 @@ import com.google.gson.JsonElement;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.tags.TagManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddPackFindersEvent;
@@ -84,7 +86,11 @@ public class CommonEventHandler {
 	}
 
 	public void onAddReloadListener(AddReloadListenerEvent event) {
-		MiscHelper.INSTANCE.setTagManager((TagManager)event.getServerResources().listeners().get(0));
+		Optional<PreparableReloadListener> tagManager = event.getServerResources().listeners().stream().filter(l -> l instanceof TagManager).findFirst();
+		if (tagManager.isEmpty()) {
+			throw new IllegalStateException("Tag manager not found.");
+		}
+		MiscHelper.INSTANCE.setTagManager((TagManager)tagManager.get());
 	}
 
 	public void onReadRecipes(Map<ResourceLocation, JsonElement> recipeMap) {


### PR DESCRIPTION
Find Minecraft TagManager in Listeners and don't expect it as first element.

Fix for [Pollen](https://www.curseforge.com/minecraft/mc-mods/pollen)