### PR TITLE
Do not throw exceptions for missing files in dynamic resource pack.

### DIFF
--- a/src/main/java/thelm/jaopca/resources/InMemoryResourcePack.java
+++ b/src/main/java/thelm/jaopca/resources/InMemoryResourcePack.java
@@ -90,23 +90,23 @@ public class InMemoryResourcePack implements IInMemoryResourcePack {
 	@Override
 	public IoSupplier<InputStream> getRootResource(String... path) {
 		String filePath = String.join("/", path);
-		return ()->{
-			if(files.containsKey(filePath)) {
-				return files.get(filePath).get();
-			}
-			throw new FileNotFoundException(filePath);
-		};
+
+		if (files.containsKey(filePath)) {
+			return ()->files.get(filePath).get();
+		}
+
+		return null;
 	}
 
 	@Override
 	public IoSupplier<InputStream> getResource(PackType type, ResourceLocation location) {
 		String filePath = getPath(type, location);
-		return ()->{
-			if(files.containsKey(filePath)) {
-				return files.get(filePath).get();
-			}
-			throw new FileNotFoundException(filePath);
-		};
+
+		if (files.containsKey(filePath)) {
+			return ()->files.get(filePath).get();
+		}
+
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Some mods don't handle the exception correctly (https://github.com/BluSunrize/ImmersiveEngineering/issues/5587) and vanilla behavior is to return `null` when file is missing.